### PR TITLE
Fix audio dependency installation: pin librosa and ensure setuptools/pkg_resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,11 +253,17 @@ install-external-py: venv ## Install external python deps required by cloned rep
 	@# Audio processing
 	@printf "$(BLUE)→ Installing audio processing stack...$(RESET)\n"
 	@$(UV) pip install --python $(VENV_BIN)/python \
+        --reinstall-package setuptools \
         "setuptools>=68.0.0" \
+        wheel \
         "librosa==0.9.2" \
         "soundfile>=0.12.0,<0.13.0" \
         "numba>=0.58.0" \
         || { printf "$(RED)✗ Audio deps failed$(RESET)\n"; exit 1; }
+	@$(VENV_BIN)/python -c "import pkg_resources, librosa; print('  ✓ pkg_resources available via setuptools; librosa:', librosa.__version__)" || { \
+        printf "$(RED)✗ Audio import check failed (pkg_resources/librosa)$(RESET)\n"; \
+        exit 1; \
+    }
 
 	@# Video processing
 	@printf "$(BLUE)→ Installing video processing stack...$(RESET)\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     # CRITICAL FIX: Wav2Lip requires librosa 0.9.x. Librosa 0.10+ breaks audio.py.
     # Librosa 0.9.x still imports pkg_resources at runtime, provided by setuptools.
     "setuptools>=68.0.0",
-    "librosa>=0.9.2",
+    "librosa==0.9.2",
     "soundfile>=0.12.0,<0.13.0",
     "numba>=0.58.0",
 


### PR DESCRIPTION
### Motivation
- Prevent runtime TTS/service crashes caused by incompatible `librosa` versions and missing `pkg_resources` used by `librosa==0.9.x` in Wav2Lip/SadTalker flows.
- Make the audio dependency install step deterministic and fail-fast with a clear message when the audio stack isn't available.

### Description
- Pin `librosa` to `0.9.2` in `pyproject.toml` to avoid installing incompatible `librosa` releases.
- Update `Makefile` `install-external-py` step to force reinstall `setuptools`, install `wheel`, and keep `librosa==0.9.2` during the audio stack installation.
- Add an install-time import check that runs `python -c "import pkg_resources, librosa; print(...)"` to verify `pkg_resources` and `librosa` are usable and to fail early with a clear error if not.

### Testing
- Ran a dry-run of the external install with `make -n install-external-py`, which produced the expected install steps without errors.
- Attempts to run `make install`, `make test`, and `make demo` were blocked by this environment's PyPI connectivity failures (packages could not be fetched), so full install/test/demo could not be completed here.
- The added import check will surface `pkg_resources/librosa` problems at install time so runtime TTS crashes can be caught earlier once network/package access is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f01470d4832dbaf5b2c293ff1be5)