### PR TITLE
Align librosa to 0.11.0, add setuptools checks, and update verification messaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,11 +253,17 @@ install-external-py: venv ## Install external python deps required by cloned rep
 	@# Audio processing
 	@printf "$(BLUE)→ Installing audio processing stack...$(RESET)\n"
 	@$(UV) pip install --python $(VENV_BIN)/python \
+        --reinstall-package setuptools \
         "setuptools>=68.0.0" \
-        "librosa==0.9.2" \
+        wheel \
+        "librosa==0.11.0" \
         "soundfile>=0.12.0,<0.13.0" \
         "numba>=0.58.0" \
         || { printf "$(RED)✗ Audio deps failed$(RESET)\n"; exit 1; }
+	@$(VENV_BIN)/python -c "import pkg_resources, librosa; print('  ✓ pkg_resources available via setuptools; librosa:', librosa.__version__)" || { \
+        printf "$(RED)✗ Audio import check failed (pkg_resources/librosa)$(RESET)\n"; \
+        exit 1; \
+    }
 
 	@# Video processing
 	@printf "$(BLUE)→ Installing video processing stack...$(RESET)\n"
@@ -340,7 +346,7 @@ verify: venv ## Verify all dependencies are installed
 	@$(VENV_BIN)/python -c "import numpy as np; print('  ✅ numpy:', np.__version__, '(must be <2.0.0)')" || printf "  $(RED)❌ numpy missing$(RESET)\n"
 	
 	@printf "\n$(BOLD)Audio/Video Processing:$(RESET)\n"
-	@$(VENV_BIN)/python -c "import librosa; print('  ✅ librosa:', librosa.__version__, '(must be 0.9.x)')" 2>/dev/null || printf "  $(RED)❌ librosa missing$(RESET)\n"
+	@$(VENV_BIN)/python -c "import librosa; print('  ✅ librosa:', librosa.__version__, '(aligned with chatterbox-tts)')" 2>/dev/null || printf "  $(RED)❌ librosa missing$(RESET)\n"
 	@$(VENV_BIN)/python -c "import soundfile; print('  ✅ soundfile installed')" || printf "  $(RED)❌ soundfile missing$(RESET)\n"
 	@$(VENV_BIN)/python -c "import ffmpeg; print('  ✅ ffmpeg-python installed')" || printf "  $(RED)❌ ffmpeg-python missing$(RESET)\n"
 	@$(VENV_BIN)/python -c "import imageio; print('  ✅ imageio installed')" || printf "  $(RED)❌ imageio missing$(RESET)\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,10 @@ dependencies = [
     "basicsr>=1.4.2,<2.0.0",
 
     # Audio processing
-    # CRITICAL FIX: Wav2Lip requires librosa 0.9.x. Librosa 0.10+ breaks audio.py.
-    # Librosa 0.9.x still imports pkg_resources at runtime, provided by setuptools.
+    # Keep this aligned with chatterbox-tts. Wav2Lip's legacy librosa call sites
+    # are patched at runtime in app/lipsync.py for modern librosa compatibility.
     "setuptools>=68.0.0",
-    "librosa>=0.9.2",
+    "librosa==0.11.0",
     "soundfile>=0.12.0,<0.13.0",
     "numba>=0.58.0",
 

--- a/scripts/verify_setup.py
+++ b/scripts/verify_setup.py
@@ -79,17 +79,17 @@ def check_numpy_version() -> bool:
 
 
 def check_librosa_version() -> bool:
-    """Check if librosa version is compatible (==0.9.2)."""
+    """Check if librosa is installed at the version required by chatterbox-tts."""
     try:
         import librosa
         version = librosa.__version__
         
-        if version.startswith('0.9'):
+        if version == '0.11.0':
             print_success(f"librosa                   (version: {version}) - Compatible")
             return True
         else:
             print_warning(f"librosa                   (version: {version}) - May cause issues")
-            print(f"  {Colors.YELLOW}→ Recommended: librosa==0.9.2 for Wav2Lip compatibility{Colors.RESET}")
+            print(f"  {Colors.YELLOW}→ Recommended: librosa==0.11.0 to match chatterbox-tts{Colors.RESET}")
             return True  # Warning, not error
     except ImportError:
         print_error(f"librosa                   - MISSING (required)")
@@ -335,7 +335,7 @@ def check_setup() -> Dict[str, bool]:
                 print(f"     {Colors.BLUE}uv pip install 'numpy<2.0.0'{Colors.RESET}")
             if not librosa_ok:
                 print(f"  3. Fix librosa version:")
-                print(f"     {Colors.BLUE}uv pip install 'librosa==0.9.2'{Colors.RESET}")
+                print(f"     {Colors.BLUE}uv pip install 'librosa==0.11.0'{Colors.RESET}")
             if not guided_diff_ok:
                 print(f"  4. Install guided_diffusion:")
                 print(f"     {Colors.BLUE}uv pip install git+https://github.com/openai/guided-diffusion.git{Colors.RESET}")


### PR DESCRIPTION
### Motivation

- Align the project's `librosa` dependency with `chatterbox-tts` and modernize compatibility for downstream audio pipelines. 
- Ensure `setuptools`/`pkg_resources` is present so runtime imports used by `librosa` and related packages do not fail silently. 
- Improve developer feedback by making verification messages and recommendations accurate for the new dependency baseline.

### Description

- Pin `librosa==0.11.0` in `pyproject.toml` and update associated dependency comments to reflect alignment with `chatterbox-tts` and runtime patches in `app/lipsync.py`.
- Modify `Makefile`'s `install-external-py` to add `--reinstall-package setuptools`, install `wheel`, switch to `librosa==0.11.0`, and add a post-install import check that runs `pkg_resources` and prints the installed `librosa` version, failing if the check does not pass.
- Update the `Makefile` `verify` target messaging for `librosa` to reference alignment with `chatterbox-tts`.
- Update `scripts/verify_setup.py` to accept `librosa==0.11.0` as the compatible version, adjust recommendation text to suggest installing `librosa==0.11.0`, and add a final newline fix.

### Testing

- Ran the updated verification script with `python scripts/verify_setup.py`, which executed dependency checks and reported expected `librosa` compatibility; the script exited successfully (0).
- Executed `make verify` in a fresh virtual environment which exercised the `verify` targets and completed without errors after the updated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f01470d4832dbaf5b2c293ff1be5)