### PR TITLE
Fix librosa dependency alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ install-external-py: venv ## Install external python deps required by cloned rep
         --reinstall-package setuptools \
         "setuptools>=68.0.0" \
         wheel \
-        "librosa==0.9.2" \
+        "librosa==0.11.0" \
         "soundfile>=0.12.0,<0.13.0" \
         "numba>=0.58.0" \
         || { printf "$(RED)✗ Audio deps failed$(RESET)\n"; exit 1; }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     # Keep this aligned with chatterbox-tts. Wav2Lip's legacy librosa call sites
     # are patched at runtime in app/lipsync.py for modern librosa compatibility.
     "setuptools>=68.0.0",
-    "librosa==0.9.2",
+    "librosa==0.11.0",
     "soundfile>=0.12.0,<0.13.0",
     "numba>=0.58.0",
 


### PR DESCRIPTION
### Motivation
- A dependency conflict made `make install` fail because `chatterbox-tts>=0.1.4` requires `librosa==0.11.0` while the project pinned `librosa==0.9.2`, producing unsatisfiable requirements.
- Aligning the project's `librosa` pin with the TTS ecosystem avoids the resolver failure during internal dependency installation.

### Description
- Updated `pyproject.toml` to pin `librosa==0.11.0` to match `chatterbox-tts` expectations. 
- Updated the `install-external-py` audio install step in the `Makefile` to install `librosa==0.11.0` as well.

### Testing
- Verified the `pyproject.toml` change with a small `tomllib` check that asserts `"librosa==0.11.0"` is present and `"librosa==0.9.2"` is absent, which passed. 
- Ran a repository search (`rg`) to confirm the old pin was removed, which passed. 
- Ran `git diff --check` to ensure no whitespace/error issues, which passed. 
- Attempted `uv lock --check && make install-internal` and `make test` but both could not complete because PyPI fetches failed due to network/tunnel errors, so install/test steps were not executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f9f0a944832dbc6d0b2dda8eecb8)