### PR TITLE
Add Wav2Lip librosa compatibility helper, WSL/GUI/launcher improvements, and `make web-demo` support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ VENV_BIN       = $(VENV_DIR)/bin
 EXT_DEPS_DIR  ?= external_deps
 MODELS_DIR    ?= $(CURDIR)/models
 IMAGE         ?= avatar-renderer:latest
+WEB_DEMO_IMAGE ?= tests/assets/alice.png
+WEB_DEMO_AUDIO ?= tests/assets/hello.wav
+WEB_DEMO_OUT   ?= frontend/public/demo.mp4
+WEB_DEMO_POSTER ?= frontend/public/demo-poster.jpg
+WEB_DEMO_QUALITY ?= real_time
+WEB_DEMO_DEPLOY ?= 0
 
 # Repos (single source of truth)
 SADTALKER_REPO ?= https://github.com/OpenTalker/SadTalker.git
@@ -466,6 +472,40 @@ demo: install ## Run demo script
         EXT_DEPS_DIR=$(CURDIR)/$(EXT_DEPS_DIR) \
         $(VENV_BIN)/python demo.py
 
+.PHONY: web-demo
+web-demo: install ## Generate/update the Vercel homepage demo video asset
+	@printf "$(BOLD)$(BLUE)Generating Vercel homepage demo video...$(RESET)\n"
+	@mkdir -p $$(dirname $(WEB_DEMO_OUT))
+	@PYTHONPATH=$(CURDIR)/$(EXT_DEPS_DIR):$(PYTHONPATH) \
+        MODEL_ROOT=$(MODELS_DIR) \
+        EXT_DEPS_DIR=$(CURDIR)/$(EXT_DEPS_DIR) \
+        $(VENV_BIN)/python demo.py \
+        --image $(WEB_DEMO_IMAGE) \
+        --audio $(WEB_DEMO_AUDIO) \
+        --out $(WEB_DEMO_OUT) \
+        --quality $(WEB_DEMO_QUALITY) \
+        --wav2lip
+	@printf "$(BLUE)Updating poster image...$(RESET)\n"
+	@ffmpeg -y -ss 00:00:01 -i $(WEB_DEMO_OUT) -frames:v 1 -q:v 2 $(WEB_DEMO_POSTER) >/tmp/avatar-web-demo-poster.log 2>&1 || { \
+        printf "$(YELLOW)⚠ Could not generate poster; see /tmp/avatar-web-demo-poster.log$(RESET)\n"; \
+        true; \
+    }
+	@printf "$(GREEN)✓ Updated frontend hero video: $(WEB_DEMO_OUT)$(RESET)\n"
+	@printf "$(GREEN)✓ Updated frontend poster: $(WEB_DEMO_POSTER)$(RESET)\n"
+	@if [ "$(WEB_DEMO_DEPLOY)" = "1" ]; then \
+        if command -v vercel >/dev/null 2>&1; then \
+            printf "$(BLUE)Deploying frontend to Vercel...$(RESET)\n"; \
+            cd frontend && vercel --prod; \
+        else \
+            printf "$(YELLOW)⚠ WEB_DEMO_DEPLOY=1 requested but vercel CLI is not installed.$(RESET)\n"; \
+            printf "$(YELLOW)  Install with: npm i -g vercel$(RESET)\n"; \
+            exit 1; \
+        fi; \
+    else \
+        printf "$(YELLOW)Next: commit the updated assets and deploy frontend/ to Vercel.$(RESET)\n"; \
+        printf "$(YELLOW)      Or run: make web-demo WEB_DEMO_DEPLOY=1$(RESET)\n"; \
+    fi
+
 .PHONY: gui
 gui: install ## Start Backend (8000) + TTS (4123) + Desktop GUI
 	@printf "$(BOLD)$(BLUE)Starting Avatar Renderer GUI (Full Stack)...$(RESET)\n\n"
@@ -503,13 +543,28 @@ gui: install ## Start Backend (8000) + TTS (4123) + Desktop GUI
         fi; \
     done
 	
-	@printf "$(BLUE)Step 4: Launching Desktop GUI...$(RESET)\n\n"
-	@PYTHONPATH=$(CURDIR)/$(EXT_DEPS_DIR):$(PYTHONPATH) \
+	@IS_WSL=0; \
+    if [ -r /proc/version ] && grep -qi microsoft /proc/version; then IS_WSL=1; fi; \
+    if [ "$$IS_WSL" = "1" ] && [ "$${FORCE_DESKTOP_GUI:-0}" != "1" ]; then \
+        printf "$(YELLOW)WSL detected: desktop Tk GUI is unstable under WSLg/X11 on this setup.$(RESET)\n"; \
+        printf "$(BLUE)Step 4: Launching Modern Web UI instead...$(RESET)\n\n"; \
+        printf "$(YELLOW)Tip: set FORCE_DESKTOP_GUI=1 to try the Tk GUI anyway.$(RESET)\n"; \
+        $(UV) pip install --python $(VENV_BIN)/python -e ".[launcher]"; \
+        PYTHONPATH=$(CURDIR)/$(EXT_DEPS_DIR):$(PYTHONPATH) \
+        MODEL_ROOT=$(MODELS_DIR) \
+        EXT_DEPS_DIR=$(CURDIR)/$(EXT_DEPS_DIR) \
+        API_URL=http://localhost:8000 \
+        LAUNCHER_MODE=$${LAUNCHER_MODE:-default} \
+        $(VENV_BIN)/python -m launcher || true; \
+    else \
+        printf "$(BLUE)Step 4: Launching Desktop GUI...$(RESET)\n\n"; \
+        PYTHONPATH=$(CURDIR)/$(EXT_DEPS_DIR):$(PYTHONPATH) \
         MODEL_ROOT=$(MODELS_DIR) \
         EXT_DEPS_DIR=$(CURDIR)/$(EXT_DEPS_DIR) \
         API_URL=http://localhost:8000 \
         CHATTERBOX_URL=http://localhost:4123 \
-        $(VENV_BIN)/python -m gui || true
+        $(VENV_BIN)/python -m gui || true; \
+    fi
 	
 	@# Cleanup
 	@printf "\n$(BLUE)Stopping background services...$(RESET)\n"

--- a/app/lipsync.py
+++ b/app/lipsync.py
@@ -29,6 +29,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from .wav2lip_compat import patch_wav2lip_audio_for_librosa
+
 log = logging.getLogger("avatar-renderer.lipsync")
 
 WAV2LIP_REPO = os.getenv("WAV2LIP_REPO", "https://github.com/Rudrabha/Wav2Lip")
@@ -67,18 +69,7 @@ def _setup() -> Path:
 
     # Make Wav2Lip's audio.py compatible with modern librosa (>=0.10), which made
     # librosa.filters.mel keyword-only. The repo calls it positionally.
-    audio_py = WAV2LIP_DIR / "audio.py"
-    try:
-        t = audio_py.read_text()
-        if "librosa.filters.mel(hp.sample_rate, hp.n_fft," in t:
-            t = t.replace(
-                "librosa.filters.mel(hp.sample_rate, hp.n_fft,",
-                "librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft,",
-            )
-            audio_py.write_text(t)
-            log.info("Patched Wav2Lip audio.py for modern librosa.")
-    except Exception as exc:  # non-fatal; may already be compatible
-        log.warning("Could not patch Wav2Lip audio.py: %s", exc)
+    patch_wav2lip_audio_for_librosa(WAV2LIP_DIR)
 
     LIPSYNC_CACHE.mkdir(parents=True, exist_ok=True)
     ckpt = LIPSYNC_CACHE / "wav2lip_gan.pth"
@@ -157,6 +148,7 @@ def _get_gfpgan(device: str):
 
 def _load_model(ckpt: Path, device: str):
     import torch
+
     from models import Wav2Lip  # from the cloned repo
 
     model = Wav2Lip()

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -26,6 +26,8 @@ from typing import Optional, Any, Tuple, List
 
 import torch
 
+from .wav2lip_compat import patch_wav2lip_audio_for_librosa
+
 log = logging.getLogger("avatar-renderer.pipeline")
 
 # --------------------------------------------------------------------------- #
@@ -490,6 +492,10 @@ def run_wav2lip(frames_dir: Path, audio_wav: str, tmp_dir: Path) -> Path:
     if not _ffmpeg_binary_available():
         log.warning("[pipeline] ffmpeg not available; returning frames without lip-sync.")
         return frames_dir
+
+    # Keep the vendored Wav2Lip subprocess compatible with librosa >= 0.10,
+    # where librosa.filters.mel requires sr/n_fft to be keyword arguments.
+    patch_wav2lip_audio_for_librosa(wav2lip_dir)
 
     silent_vid = tmp_dir / "wav2lip_input.mp4"
     out_vid = tmp_dir / "wav2lip_out.mp4"

--- a/app/wav2lip_compat.py
+++ b/app/wav2lip_compat.py
@@ -1,0 +1,42 @@
+"""Compatibility helpers for vendored Wav2Lip code."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger("avatar-renderer.wav2lip_compat")
+
+_LEGACY_MEL_CALL = "librosa.filters.mel(hp.sample_rate, hp.n_fft,"
+_MODERN_MEL_CALL = "librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft,"
+
+
+def patch_wav2lip_audio_for_librosa(wav2lip_dir: Path) -> bool:
+    """Patch Wav2Lip's legacy librosa mel call for librosa >= 0.10.
+
+    Wav2Lip's upstream ``audio.py`` calls ``librosa.filters.mel`` with the
+    sample rate and FFT size as positional arguments. Modern librosa made those
+    parameters keyword-only, so subprocess Wav2Lip fails with:
+    ``TypeError: mel() takes 0 positional arguments...``.
+
+    Returns ``True`` when a file was changed and ``False`` when the file was
+    already compatible, missing, or could not be patched.
+    """
+    audio_py = wav2lip_dir / "audio.py"
+    try:
+        text = audio_py.read_text()
+    except OSError as exc:
+        log.warning("Could not read Wav2Lip audio.py for librosa compatibility patch: %s", exc)
+        return False
+
+    if _LEGACY_MEL_CALL not in text:
+        return False
+
+    try:
+        audio_py.write_text(text.replace(_LEGACY_MEL_CALL, _MODERN_MEL_CALL))
+    except OSError as exc:
+        log.warning("Could not patch Wav2Lip audio.py for modern librosa: %s", exc)
+        return False
+
+    log.info("Patched Wav2Lip audio.py for modern librosa compatibility.")
+    return True

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -281,3 +281,25 @@ See parent directory for contribution guidelines.
 For issues and questions:
 - Backend issues: See parent directory README
 - Frontend issues: Create an issue in the repository
+
+## Updating the homepage demo video
+
+The production page at `https://avatar-renderer-mcp.vercel.app/` plays the static
+hero assets from `frontend/public/demo.mp4` and `frontend/public/demo-poster.jpg`.
+From the repository root, regenerate both assets with:
+
+```bash
+make web-demo
+```
+
+To generate and deploy in one step when the Vercel CLI is installed and logged in:
+
+```bash
+make web-demo WEB_DEMO_DEPLOY=1
+```
+
+You can override inputs without editing files:
+
+```bash
+make web-demo WEB_DEMO_IMAGE=tests/assets/alice.png WEB_DEMO_AUDIO=tests/assets/hello.wav WEB_DEMO_QUALITY=real_time
+```

--- a/gui/avatar_gui.py
+++ b/gui/avatar_gui.py
@@ -43,7 +43,21 @@ def initialize_x11_threading():
         os.environ['MPLBACKEND'] = 'Agg'  # Non-interactive matplotlib backend
         os.environ['QT_X11_NO_MITSHM'] = '1'  # Disable problematic X11 extension
 
-        # Initialize X11 threading FIRST
+        # WSLg/Tk can abort inside libX11/xcb when XInitThreads() is forced:
+        #   [xcb] Unknown sequence number while appending request
+        #   [xcb] You called XInitThreads, this is not your fault
+        # Tkinter itself is single-threaded, so the safest default is to avoid
+        # XInitThreads on WSL and marshal all widget updates through Tk.after().
+        if is_wsl and os.getenv('AVATAR_GUI_XINITTHREADS') != '1':
+            print("[INFO] WSL detected; skipping XInitThreads to avoid WSLg XCB abort")
+            print("[INFO] Set AVATAR_GUI_XINITTHREADS=1 to force legacy XInitThreads behavior")
+            return
+
+        # Initialize X11 threading FIRST for non-WSL Linux, unless explicitly disabled.
+        if os.getenv('AVATAR_GUI_XINITTHREADS') == '0':
+            print("[INFO] XInitThreads disabled by AVATAR_GUI_XINITTHREADS=0")
+            return
+
         try:
             x11_lib = ctypes.util.find_library('X11')
             if x11_lib:
@@ -405,13 +419,17 @@ class AvatarGeneratorGUI(tk.Tk):
         self.progress_bar.start(10)
         self.status_var.set("Generating Audio...")
 
-        threading.Thread(target=self._worker_audio, args=(text,), daemon=True).start()
+        lang = self._get_lang_code()
+        voice_data = VOICE_PROFILES[self.voice_var.get()]
 
-    def _worker_audio(self, text):
+        threading.Thread(
+            target=self._worker_audio,
+            args=(text, lang, voice_data),
+            daemon=True,
+        ).start()
+
+    def _worker_audio(self, text, lang, voice_data):
         try:
-            lang = self._get_lang_code()
-            voice_data = VOICE_PROFILES[self.voice_var.get()]
-
             payload = {
                 "text": text, "language": lang,
                 "voice": voice_data["voice"], "temperature": voice_data["temperature"],
@@ -476,9 +494,17 @@ class AvatarGeneratorGUI(tk.Tk):
         # Switch to log tab
         self.notebook.select(2)
 
-        threading.Thread(target=self._worker_render, daemon=True).start()
+        q_mode = QUALITY_MODES[self.quality_var.get()]
+        avatar_image_path = Path(self.avatar_image_path)
+        generated_audio_path = Path(self.generated_audio_path)
 
-    def _worker_render(self):
+        threading.Thread(
+            target=self._worker_render,
+            args=(q_mode, avatar_image_path, generated_audio_path),
+            daemon=True,
+        ).start()
+
+    def _worker_render(self, q_mode, avatar_image_path, generated_audio_path):
         try:
             self.after(0, lambda: self._log("Initializing pipeline... (First run takes ~10s)"))
 
@@ -494,16 +520,14 @@ class AvatarGeneratorGUI(tk.Tk):
             timestamp = time.strftime("%Y%m%d_%H%M%S")
             video_out = OUTPUT_DIR / f"avatar_{timestamp}.mp4"
 
-            q_mode = QUALITY_MODES[self.quality_var.get()]
-
             self.after(0, lambda: self._log(f"Starting render: {q_mode}"))
-            self.after(0, lambda: self._log(f"Image: {Path(self.avatar_image_path).name}"))
+            self.after(0, lambda: self._log(f"Image: {avatar_image_path.name}"))
             self.after(0, lambda: self._log("Processing..."))
 
             # RUN PIPELINE
             result_path = render_pipeline(
-                face_image=str(self.avatar_image_path),
-                audio=str(self.generated_audio_path),
+                face_image=str(avatar_image_path),
+                audio=str(generated_audio_path),
                 out_path=str(video_out),
                 quality_mode=q_mode
             )

--- a/launcher/app.py
+++ b/launcher/app.py
@@ -350,6 +350,25 @@ def get_sample_text(language: str, sample_type: str):
     samples = SAMPLE_TEXTS.get(language, SAMPLE_TEXTS.get("en", {}))
     return samples.get(sample_type, "")
 
+def _running_under_wsl() -> bool:
+    try:
+        return "microsoft" in Path("/proc/version").read_text().lower()
+    except OSError:
+        return False
+
+
+def _launcher_mode() -> str:
+    mode = os.getenv("LAUNCHER_MODE")
+    if mode:
+        return mode
+    # WSLg can crash native X11/Tk clients with xcb assertions. Use the default
+    # browser integration in WSL so the UI can open in Windows/WSLg without
+    # forcing Eel's Chrome-specific Linux window mode.
+    if _running_under_wsl():
+        return "default"
+    return "chrome"
+
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -365,12 +384,15 @@ def main():
                 try: f.unlink()
                 except: pass
 
+        mode = _launcher_mode()
+        print(f"[INFO] Launcher URL: http://localhost:8080/index.html")
+        print(f"[INFO] Browser mode: {mode}")
         eel.start(
             'index.html',
             size=(1280, 850),
             port=8080,
-            mode='chrome',
-            cmdline_args=['--disable-http-cache'] 
+            mode=mode,
+            cmdline_args=['--disable-http-cache']
         )
     except Exception as e:
         print(f"[FATAL] {e}")

--- a/tests/test_wav2lip_compat.py
+++ b/tests/test_wav2lip_compat.py
@@ -1,0 +1,24 @@
+from app.wav2lip_compat import patch_wav2lip_audio_for_librosa
+
+
+def test_patch_wav2lip_audio_for_modern_librosa(tmp_path):
+    audio_py = tmp_path / "audio.py"
+    audio_py.write_text(
+        "return librosa.filters.mel(hp.sample_rate, hp.n_fft, n_mels=hp.num_mels,\n"
+        "                           fmin=hp.fmin, fmax=hp.fmax)\n"
+    )
+
+    assert patch_wav2lip_audio_for_librosa(tmp_path) is True
+    patched = audio_py.read_text()
+    assert "librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft," in patched
+    assert "librosa.filters.mel(hp.sample_rate, hp.n_fft," not in patched
+
+
+def test_patch_wav2lip_audio_is_idempotent(tmp_path):
+    audio_py = tmp_path / "audio.py"
+    audio_py.write_text(
+        "return librosa.filters.mel(sr=hp.sample_rate, n_fft=hp.n_fft, n_mels=hp.num_mels)\n"
+    )
+
+    assert patch_wav2lip_audio_for_librosa(tmp_path) is False
+    assert "sr=hp.sample_rate" in audio_py.read_text()


### PR DESCRIPTION
### Motivation

- Ensure vendored Wav2Lip continues to work with modern `librosa` (>=0.10) where `librosa.filters.mel` became keyword-only. 
- Improve desktop UX under WSL by avoiding fragile X11 threading behavior and preferring the web launcher where appropriate. 
- Provide a reproducible developer workflow to generate and update the frontend hero demo video used on the Vercel homepage.

### Description

- Add `app/wav2lip_compat.py` implementing `patch_wav2lip_audio_for_librosa` to patch Wav2Lip's `audio.py` mel-call to use keyword args. 
- Wire the compat helper into `app/lipsync.py` and `app/pipeline.py` so both in-process and subprocess Wav2Lip paths are made compatible with modern `librosa`. 
- Add unit tests in `tests/test_wav2lip_compat.py` to validate the patching behavior and idempotency. 
- Add a `web-demo` Makefile target and related variables (`WEB_DEMO_*`) to generate `frontend/public/demo.mp4` and poster image and optionally deploy to Vercel. 
- Improve GUI robustness by skipping `XInitThreads` under WSL by default and marshaling widget updates through `Tk.after`, and pass explicit args into background audio/video worker threads to avoid racey access to UI state. 
- Make the launcher detect WSL and choose a safer default `mode` (browser integration) instead of forcing Chrome, and print the selected mode at startup. 
- Update `frontend/README.md` with instructions for regenerating and deploying the homepage demo assets.

### Testing

- Ran the new unit tests via `pytest tests/test_wav2lip_compat.py` and they passed. 
- No other automated test changes were added in this patch, and existing integration paths were left untouched so normal runtime fallbacks remain in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56008c0e54832db6df49135d805d8e)